### PR TITLE
sdk: Add an option to force pre-O apps to use full screen aspect ratio

### DIFF
--- a/lineage/res/res/values/config.xml
+++ b/lineage/res/res/values/config.xml
@@ -208,4 +208,10 @@
           platform signatures, specifically for use on devices with a vendor partition. -->
       <string-array name="config_vendorPlatformSignatures">
       </string-array>
+
+    <!-- Whether device has screen with higher aspect ratio -->
+    <bool name="config_haveHigherAspectRatioScreen">false</bool>
+
+    <!-- Aspect ratio of screen -->
+    <item name="config_screenAspectRatio" format="float" type="dimen">2.1</item>
 </resources>

--- a/lineage/res/res/values/symbols.xml
+++ b/lineage/res/res/values/symbols.xml
@@ -153,4 +153,8 @@
     <java-symbol type="string" name="accent_yellow" />
 
     <java-symbol type="array" name="config_vendorPlatformSignatures" />
+
+    <!-- Full screen aspect ratio -->
+    <java-symbol type="bool" name="config_haveHigherAspectRatioScreen" />
+    <java-symbol type="dimen" name="config_screenAspectRatio" />
 </resources>

--- a/sdk/src/java/lineageos/providers/LineageSettings.java
+++ b/sdk/src/java/lineageos/providers/LineageSettings.java
@@ -832,6 +832,15 @@ public final class LineageSettings {
                 sBooleanValidator;
 
         /**
+         * Whether or not to force full screen aspect ratio
+         * 0 = off, 1 = on
+         */
+        public static final String FULL_SCREEN_ASPECT_RATIO = "full_screen_aspect_ratio";
+
+        /** @hide */
+        public static final Validator FULL_SCREEN_ASPECT_RATIO_VALIDATOR = sBooleanValidator;
+
+        /**
          * Whether to enable system profiles feature
          * 0 = off, 1 = on
          */
@@ -2155,6 +2164,7 @@ public final class LineageSettings {
             VALIDATORS.put(NOTIFICATION_PLAY_QUEUE, NOTIFICATION_PLAY_QUEUE_VALIDATOR);
             VALIDATORS.put(HIGH_TOUCH_SENSITIVITY_ENABLE,
                     HIGH_TOUCH_SENSITIVITY_ENABLE_VALIDATOR);
+            VALIDATORS.put(FULL_SCREEN_ASPECT_RATIO, FULL_SCREEN_ASPECT_RATIO_VALIDATOR);
             VALIDATORS.put(SYSTEM_PROFILES_ENABLED, SYSTEM_PROFILES_ENABLED_VALIDATOR);
             VALIDATORS.put(STATUS_BAR_CLOCK, STATUS_BAR_CLOCK_VALIDATOR);
             VALIDATORS.put(STATUS_BAR_AM_PM, STATUS_BAR_AM_PM_VALIDATOR);


### PR DESCRIPTION
When an app target pre-O releases, the default max aspect ratio
is 1.86:1 which leads to ugly black areas on devices that have
screens with higher aspect ratio (for example Galaxy S8/S9).

This change adds an option to allow users to change default
aspect ratio for pre-O apps to 2.1 which would fit recent devices.

Change-Id: I4c243ef06655cf9acc23530e7307c4b0b68b0621